### PR TITLE
fix(docs): build docs on release, not push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,8 @@
 name: Documentation
 
 on:
-  push:
-    branches-ignore:
-      - "dependabot/**"
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
it's too hard work to do it everytime, when something is pushed