### PR TITLE
fix(docs): remove includable, types references

### DIFF
--- a/docs/reference/includable.md
+++ b/docs/reference/includable.md
@@ -1,1 +1,0 @@
-::: aurum.includable

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,1 +1,0 @@
-::: aurum.types


### PR DESCRIPTION
I didn't notice this problem before, but it's fixed and documentation will build successfully, sorry for inconvenience.